### PR TITLE
Provide empty value as "" instead of NULL to avoid wp_kses_post type error

### DIFF
--- a/src/Category_Colors/CSS/Extras.php
+++ b/src/Category_Colors/CSS/Extras.php
@@ -161,7 +161,7 @@ class Extras {
 		 * @return string string is returned not echoed.
 		 *                default return string is empty.
 		 */
-		echo wp_kses_post( apply_filters( 'teccc_fix_category_link_color', null, '.tribe-events-category-' . $slug ) );
+		echo wp_kses_post( apply_filters( 'teccc_fix_category_link_color', '', '.tribe-events-category-' . $slug ) );
 	}
 
 	/**


### PR DESCRIPTION
[`wp_kses()` (used here through `wp_kses_post()` is typed to receive a "array|string"](https://developer.wordpress.org/reference/functions/wp_kses/). Passing NULL causes a deprecation warning,

    Deprecated: preg_replace():
    Passing null to parameter #3 ($subject) of type array|string is deprecated
    in /wp/wp-includes/kses.php on line 1745 [$ /usr/local/bin/wp plugin list]
    [
    	wp-includes/kses.php:1745 preg_replace(),
    	wp-includes/kses.php:752 wp_kses_no_null(),
    	wp-includes/kses.php:2172 wp_kses(),
    	wp-content/plugins/the-events-calendar-category-colors/src/Category_Colors/CSS/Extras.php:164,
    	...

Changing the "empty" value to `''` fixes this by ensuring the default is a string throughout.