### PR TITLE
Fix - adapt to the new TEC settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # The Events Calendar: Category Colors
 
 * Contributors: theeventscalendar, afragen, barry.hughes
-* Donate link: <https://thefragens.com/category-colors-donate>
 * Tags: events, color, calendar, category
 * License: GPLv2 or later
 * License URI: <https://www.gnu.org/licenses/gpl-2.0.html>
-* Requires at least: 5.2
-* Requires PHP: 7.1
+* Requires at least: 6.3
+* Requires PHP: 7.4
 
 Add event category background colors to The Events Calendar events.
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "afragen/the-events-calendar-category-colors",
+    "name": "the-events-calendar/the-events-calendar-category-colors",
     "description": "This plugin adds event category background coloring to The Events Calendar plugin.",
     "type": "wordpress-plugin",
     "keywords": [
@@ -11,6 +11,11 @@
     ],
     "license": "GPL-3.0-or-later",
     "authors": [
+		{
+			"name": "The Events Calendar",
+			"homepage": "https://evnt.is/1x",
+			"role": "Developer"
+		},
         {
             "name": "Andy Fragen",
             "email": "andy@thefragens.com",
@@ -34,7 +39,7 @@
     },
     "prefer-stable": true,
     "require": {
-        "php": ">=7.1"
+        "php": ">=7.4"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "^3.0.0"

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,10 @@
 # The Events Calendar: Category Colors
 Contributors: theeventscalendar, afragen, barry.hughes
-Donate link: https://theeventscalendar.com
 Tags: events, color, calendar, category
-Requires at least: 5.2
-Requires PHP: 7.1
+Requires at least: 6.3
+Requires PHP: 7.4
 Tested up to: 6.6
-Stable tag: 7.3.2
+Stable tag: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -55,6 +54,10 @@ Make sure you are reporting in a safe and responsible way. We take security very
 
 ## Changelog
 
+#### 7.4.0 / 2024-10-07
+
+* Version -
+
 #### 7.3.2 / 2024-08-20
 
 * Fix - Resolve problems when Hide option not hiding categories on the frontend. (props @afragen) [TEC-5139]
@@ -70,7 +73,7 @@ Make sure you are reporting in a safe and responsible way. We take security very
 * yeah Barry 🙌
 
 #### 7.2.0 / 2023-03-02
-* update `Frontend::show_legend()` to accomodate multiple calendar views on single page
+* update `Frontend::show_legend()` to accommodate multiple calendar views on single page
 
 #### 7.1.2 / 2023-01-27
 * TEC converted `$view->get_slug()` to `$view::get_view_slug()` in https://github.com/the-events-calendar/the-events-calendar/pull/4091
@@ -81,7 +84,7 @@ Make sure you are reporting in a safe and responsible way. We take security very
 
 #### 7.1.0 / 2022-10-12
 * rename title to correspond to The Events Calendar standard
-* retructure CSS additions to not end with comma, added in `category.css.php`
+* restructure CSS additions to not end with comma, added in `category.css.php`
 * fix empty spacer classes to be transparent
 * add CSS for TEC/ECP 6.0 feature events
 
@@ -126,7 +129,7 @@ Make sure you are reporting in a safe and responsible way. We take security very
 
 #### 6.6.0 / 2021-07-07
 * add @10up GitHub Actions for WordPress SVN integration
-* **Reset** button added to legend in settings, navigate back to main calendar, thanks @andrasgueso
+* **Reset** button added to legend in settings, navigate back to main calendar, thanks @andrasguseo
 
 #### 6.5.0 / 2021-05-16
 * updated to fix CSS url if running on non-standard port
@@ -165,7 +168,7 @@ Make sure you are reporting in a safe and responsible way. We take security very
 * now strip CSS URL scheme to avoid mixed media errors from server
 
 #### 6.4.1 - 6.4.3 / 2020-01-28
-* test explicity for `$template instanceof \Tribe\Events\Views\V2\Template`, fixes bug when also using Events Tickets
+* test explicitly for `$template instanceof \Tribe\Events\Views\V2\Template`, fixes bug when also using Events Tickets
 * fix Superpowers JS error, `ReferenceError: Can't find variable: tribe` and `views`
 
 #### 6.4.0 / 2020-01-27
@@ -210,7 +213,7 @@ Make sure you are reporting in a safe and responsible way. We take security very
 * refactor setup of ignored terms and term data
 * add `border-right` to featured events
 * updated validation code upon saving options
-* use `wp_upload_url()` to for stylesheet to accomodate user directory preferences
+* use `wp_upload_url()` to for stylesheet to accommodate user directory preferences
 * set SSL corrected URLs for `wp_upload_url()`, <https://core.trac.wordpress.org/ticket/25449>
 
 #### 5.2.2 / 2018-07-28

--- a/src/Category_Colors/Admin.php
+++ b/src/Category_Colors/Admin.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 
@@ -12,6 +12,7 @@ namespace Fragen\Category_Colors;
 
 use Tribe__Events__Main;
 use Tribe__Settings_Tab;
+use Tribe\Events\Admin\Settings;
 
 /**
  * Class Admin
@@ -28,7 +29,7 @@ class Admin {
 	protected $teccc;
 
 	/**
-	 * Contructor
+	 * Constructor
 	 *
 	 * @param Main $teccc Class Main.
 	 */
@@ -45,7 +46,7 @@ class Admin {
 	public function load_hooks() {
 		add_action( 'admin_init', [ $this, 'register_setting' ] );
 		add_action( 'admin_notices', [ $this, 'plugin_fail_msg' ] );
-		add_action( 'tribe_settings_below_tabs_tab_category-colors', [ $this, 'is_saved' ] );
+		//add_action( 'tribe_settings_below_tabs_tab_category-colors', [ $this, 'is_saved' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'load_teccc_js_css' ] );
 	}
 
@@ -55,7 +56,7 @@ class Admin {
 	 * @return void
 	 */
 	public function register_setting() {
-		register_setting( 'teccc_category_colors', 'teccc_options', [ $this, 'validate_options' ] );
+		register_setting( 'teccc_category_colors', 'teccc_options' );
 	}
 
 	/**
@@ -160,18 +161,29 @@ class Admin {
 	 * @return void
 	 */
 	public function add_category_colors_tab() {
-		$categoryColorsTab = $this->teccc->load_config( 'admintab' );
-		add_action( 'tribe_settings_form_element_tab_category-colors', [ $this, 'form_header' ] );
+		// Only load on event settings, not ticket settings.
+		if ( ! tribe( Settings::class )->is_tec_events_settings() ) {
+			return;
+		}
+
+		// add_action( 'tribe_settings_form_element_tab_category-colors', [ $this, 'form_header' ] );
 		add_action( 'tribe_settings_before_content_tab_category-colors', [ $this, 'settings_fields' ] );
-		new Tribe__Settings_Tab( self::TAB_NAME, esc_html__( 'Category Colors', 'the-events-calendar-category-colors' ), $categoryColorsTab );
+
+		new Tribe__Settings_Tab(
+			self::TAB_NAME,
+			esc_html__( 'Category Colors', 'the-events-calendar-category-colors' ),
+			$this->teccc->load_config( 'admintab' )
+		);
 	}
 
 	/**
 	 * Form header
 	 *
+	 * @deprecated TBD
 	 * @return void
 	 */
 	public function form_header() {
+		_deprecated_function( __METHOD__, 'TBD', 'Now uses the settings form.' );
 		echo '<form method="post" action="options.php">';
 	}
 
@@ -186,8 +198,11 @@ class Admin {
 
 	/**
 	 * Display 'saved' notice
+	 *
+	 * @deprecated TBD
 	 */
 	public function is_saved() {
+		_deprecated_function( __METHOD__, 'TBD', "Now uses the settings form's built-in message." );
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['settings-updated'] ) && sanitize_key( wp_unslash( $_GET['settings-updated'] ) ) ) {
 			$message = esc_html__( 'Settings saved.', 'the-events-calendar-category-colors' );
@@ -199,9 +214,13 @@ class Admin {
 	/**
 	 * Options elements
 	 *
+	 * @deprecated TBD
+	 *
 	 * @return string
 	 */
 	public static function options_elements() {
+		_deprecated_function( __METHOD__, 'TBD', 'Now uses the settings form API.' );
+
 		$teccc = Main::instance();
 
 		$content = $teccc->view(

--- a/src/Category_Colors/Bootstrap.php
+++ b/src/Category_Colors/Bootstrap.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/Category_Colors/CSS/Base_CSS.php
+++ b/src/Category_Colors/CSS/Base_CSS.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/Category_Colors/CSS/Extras.php
+++ b/src/Category_Colors/CSS/Extras.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/Category_Colors/CSS/Pro.php
+++ b/src/Category_Colors/CSS/Pro.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/Category_Colors/CSS/V2_Views.php
+++ b/src/Category_Colors/CSS/V2_Views.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/Category_Colors/CSS/Widgets.php
+++ b/src/Category_Colors/CSS/Widgets.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 
@@ -309,6 +309,8 @@ class Frontend {
 	 * @return bool
 	 */
 	public function reposition_legend( $tribeViewFilter ) {
+		_deprecated_function( __FUNCTION__, '6.8.4.3' );
+
 		// If the legend has already run they are probably doing something wrong.
 		if ( $this->legendFilterHasRun ) {
 			_doing_it_wrong(
@@ -333,6 +335,8 @@ class Frontend {
 	 * @return bool
 	 */
 	public function remove_default_legend() {
+		_deprecated_function( __FUNCTION__, '6.8.4.3' );
+
 		// If the legend has already run they are probably doing something wrong.
 		if ( $this->legendFilterHasRun ) {
 			_doing_it_wrong(

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -290,10 +290,6 @@ class Frontend {
 			false
 		);
 
-		if ( ! empty( $this->options['add_legend'] ) && empty( $this->options['custom_legend_css'] ) ) {
-			$content .= $this->teccc->view( 'legend.css' );
-		}
-
 		$this->legendFilterHasRun[ $this->currentDisplay ] = true;
 
 		/**

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -156,6 +156,7 @@ class Frontend {
 	public function add_scripts_styles() {
 		wp_register_style( 'teccc-nofile-stylesheet', false, [], Main::$version );
 		wp_enqueue_style( 'teccc-nofile-stylesheet' );
+		error_log( print_r( $this->generate_css(), true) );
 		wp_add_inline_style( 'teccc-nofile-stylesheet', $this->generate_css() );
 
 		// Optionally add legend superpowers.

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -264,9 +264,9 @@ class Frontend {
 		if ( ! $v2_viewable && ! $is_extra_view ) {
 			return false;
 		}
-		if ( ! isset( $this->legendFilterHasRun[ $this->currentDisplay ] ) ) {
-			$this->legendFilterHasRun[ $this->currentDisplay ] = false;
-		}
+
+		$this->legendFilterHasRun[ $this->currentDisplay ] = $this->legendFilterHasRun[ $this->currentDisplay ] ?? false;
+
 		if ( $this->legendFilterHasRun[ $this->currentDisplay ] ) {
 			return false;
 		}
@@ -279,6 +279,8 @@ class Frontend {
 			return false;
 		}
 
+		error_log( 'adding legend to view: ' . $this->currentDisplay );
+
 		$content = $this->teccc->view(
 			'legend',
 			[
@@ -288,6 +290,10 @@ class Frontend {
 			],
 			false
 		);
+
+		if ( ! empty( $this->options['add_legend'] ) && empty( $this->options['custom_legend_css'] ) ) {
+			$content .= $this->teccc->view( 'legend.css' );
+		}
 
 		$this->legendFilterHasRun[ $this->currentDisplay ] = true;
 

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -160,9 +160,7 @@ class Frontend {
 		wp_add_inline_style( 'teccc-nofile-stylesheet', $this->generate_css() );
 
 		// Optionally add legend superpowers.
-		if ( isset( $this->options['legend_superpowers'] )
-			&& '1' === $this->options['legend_superpowers']
-		) {
+		if ( ! empty( $this->options['legend_superpowers'] ) ) {
 			wp_register_script( 'legend_superpowers', $this->teccc->resources_url . '/legend-superpowers.js', [ 'jquery' ], Main::$version, true );
 			wp_enqueue_script( 'legend_superpowers' );
 		}

--- a/src/Category_Colors/Frontend.php
+++ b/src/Category_Colors/Frontend.php
@@ -279,8 +279,6 @@ class Frontend {
 			return false;
 		}
 
-		error_log( 'adding legend to view: ' . $this->currentDisplay );
-
 		$content = $this->teccc->view(
 			'legend',
 			[

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -163,7 +163,6 @@ class Main {
 
 		add_action( 'init', [ $this, 'show_legend_on_views' ] );
 		add_action( 'update_option_teccc_options', [ $this->public, 'generate_css_on_update_option' ] );
-		add_action( 'teccc_add_legend_css', [ $this, 'enqueue_legend_css' ] );
 	}
 
 	/**
@@ -494,11 +493,5 @@ class Main {
 		update_option( 'teccc_options', $options );
 
 		return $options;
-	}
-
-	public function enqueue_legend_css() {
-		if ( ! empty( $options['add_legend'] ) && empty( $options['custom_legend_css'] ) ) {
-			$this->view( 'legend.css' );
-		}
 	}
 }

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -432,7 +432,7 @@ class Main {
 		if ( ! isset( $tmp['chk_default_options_db'] ) ) {
 			return false;
 		}
-		if ( '1' === $tmp['chk_default_options_db'] || ! is_array( $tmp ) ) {
+		if ( ! empty( $tmp['chk_default_options_db'] ) || ! is_array( $tmp ) ) {
 			delete_option( 'teccc_options' );
 			for ( $i = 0; $i < $teccc->count; $i++ ) {
 				$arr[ $teccc->slugs[ $i ] . '-text' ]       = '#000';

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -11,6 +11,7 @@
 namespace Fragen\Category_Colors;
 
 use Tribe__Events__Main;
+use Tribe\Events\Views\V2\Manager;
 
 /**
  * Class Main
@@ -162,6 +163,7 @@ class Main {
 
 		add_action( 'init', [ $this, 'show_legend_on_views' ] );
 		add_action( 'update_option_teccc_options', [ $this->public, 'generate_css_on_update_option' ] );
+		add_action( 'teccc_add_legend_css', [ $this, 'enqueue_legend_css' ] );
 	}
 
 	/**
@@ -174,15 +176,8 @@ class Main {
 			return;
 		}
 
-		$views = [
-			'list',
-			'month',
-			'day',
-			'week',
-			'photo',
-			'map',
-			'summary',
-		];
+		// Only add the active views.
+		$views = array_keys( tribe( Manager::class )->get_publicly_visible_views() );
 
 		if ( ! is_array( $options['add_legend'] ) ) {
 			$options = $this->update_view_options( $views, $options );
@@ -499,5 +494,11 @@ class Main {
 		update_option( 'teccc_options', $options );
 
 		return $options;
+	}
+
+	public function enqueue_legend_css() {
+		if ( ! empty( $options['add_legend'] ) && empty( $options['custom_legend_css'] ) ) {
+			$this->view( 'legend.css' );
+		}
 	}
 }

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 
@@ -327,9 +327,9 @@ class Main {
 	}
 
 	/**
-	 * Removes terms on the ignore list from the list of terms recognised by the plugin.
+	 * Removes terms on the ignore list from the list of terms recognized by the plugin.
 	 *
-	 * @param arrat $term_list Array of terms.
+	 * @param array $term_list Array of terms.
 	 *
 	 * @return array
 	 */
@@ -442,8 +442,8 @@ class Main {
 			delete_option( 'teccc_options' );
 			for ( $i = 0; $i < $teccc->count; $i++ ) {
 				$arr[ $teccc->slugs[ $i ] . '-text' ]       = '#000';
-				$arr[ $teccc->slugs[ $i ] . '-background' ] = '#CFCFCF';
-				$arr[ $teccc->slugs[ $i ] . '-border' ]     = '#CFCFCF';
+				$arr[ $teccc->slugs[ $i ] . '-background' ] = '#cfcfcf';
+				$arr[ $teccc->slugs[ $i ] . '-border' ]     = '#cfcfcf';
 			}
 			$arr['font_weight']    = 'bold';
 			$arr['featured-event'] = '#0ea0d7';

--- a/src/Category_Colors/Settings.php
+++ b/src/Category_Colors/Settings.php
@@ -457,15 +457,16 @@ class Settings {
 		];
 
 		$this->teccc_settings['add_legend'] = [
-			'type'          => 'checkbox_list',
-			'label'         => __( 'Show Category Legend', 'the-events-calendar-category-colors' ),
-			'tooltip'       => __( 'Choose where to show the category legend.', 'the-events-calendar-category-colors' ),
-			'parent_option' => 'teccc_options',
-			'options'       => array_map(
+			'type'            => 'checkbox_list',
+			'label'           => __( 'Show Category Legend', 'the-events-calendar-category-colors' ),
+			'tooltip'         => __( 'Choose where to show the category legend.', 'the-events-calendar-category-colors' ),
+			'parent_option'   => 'teccc_options',
+			'validation_type' => 'options_multi',
+			'options'         => array_map(
 				static function ( $view ) {
 					return tribe( Manager::class )->get_view_label_by_class( $view );
 				},
-				tribe( Manager::class )->get_publicly_visible_views( false )
+				tribe( Manager::class )->get_publicly_visible_views()
 			),
 		];
 

--- a/src/Category_Colors/Settings.php
+++ b/src/Category_Colors/Settings.php
@@ -487,6 +487,7 @@ class Settings {
 			'type'            => 'text',
 			'label'           => __( 'Reset Button Label', 'the-events-calendar-category-colors' ),
 			'parent_option'   => 'teccc_options',
+			'validation_type' => 'textarea',
 
 		];
 
@@ -496,6 +497,7 @@ class Settings {
 			'tooltip'         => __( 'By default the reset button will point to the default calendar URL.', 'the-events-calendar-category-colors' ),
 			'placeholder'     => tribe_get_events_link(),
 			'parent_option'   => 'teccc_options',
+			'validation_type' => 'url',
 		];
 
 		$this->teccc_settings['legend_superpowers_options_title'] = [

--- a/src/Category_Colors/Settings.php
+++ b/src/Category_Colors/Settings.php
@@ -454,6 +454,7 @@ class Settings {
 			'options'         => $this->teccc->font_weights,
 			'attributes'      => [ 'id' => 'teccc_font_weight' ],
 			'parent_option'   => 'teccc_options',
+			'validation_type' => 'options',
 		];
 
 		$this->teccc_settings['add_legend'] = [

--- a/src/Category_Colors/Settings.php
+++ b/src/Category_Colors/Settings.php
@@ -1,0 +1,435 @@
+<?php
+/**
+ * The Events Calendar: Category Colors - Settings.
+ *
+ * @package Fragen\Category_Colors
+ */
+
+namespace Fragen\Category_Colors;
+
+/**
+ * Settings class.
+ *
+ * Handles the setting form output.
+ *
+ * @since TBD
+ */
+class Settings {
+
+	/**
+	 * Holds an instance of the Main class.
+	 *
+	 * @since TBD
+	 *
+	 * @var Main
+	 */
+	private $teccc;
+
+	/**
+	 * Holds the options array.
+	 *
+	 * @since TBD
+	 *
+	 * @var array
+	 */
+	private $options;
+
+	/**
+	 * Holds the fields output for the settings form.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $teccc_settings;
+
+	/**
+	 * Do the settings output (fields).
+	 *
+	 * Returns an array to be consumed by the TEC Settings API.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,mixed> Array of settings fields.
+	 */
+	public function do_settings() {
+		// Get the Main instance.
+		$this->teccc = Main::instance();
+
+		// Get the options.
+		$this->options = get_option( 'teccc_options' );
+
+		// Setup the terms.
+		$this->teccc->setup_terms( $this->options );
+
+		// Start the table.
+		$this->teccc_settings = [
+			'tec_category_colors__table_start' => [
+				'type' => 'html',
+				'html' => '<table class="teccc form-table tec-settings-form__content-section" xmlns="http://www.w3.org/1999/html">
+				<tr>
+					<th style="width:10px;">' . esc_html( 'Hide', 'the-events-calendar-category-colors' ) . '</th>
+					<th>' . esc_html( 'Category Slug', 'the-events-calendar-category-colors' ) . '</th>
+					<th>' . esc_html( 'Border Color', 'the-events-calendar-category-colors' ) . '</th>
+					<th>' . esc_html( 'Background Color', 'the-events-calendar-category-colors' ) . '</th>
+					<th>' . esc_html( 'Text Color', 'the-events-calendar-category-colors' ) . '</th>
+					<th>' . esc_html( 'Current Display', 'the-events-calendar-category-colors' ) . '</th>
+				</tr>',
+				],
+		];
+
+
+		foreach ( (array) $this->teccc->all_terms as $option ) {
+			$this->do_color_settings_row( $option );
+		}
+
+		$this->teccc_settings['tec_category_colors_table_end'] = [
+			'type' => 'html',
+			'html' => '</table>',
+		];
+
+		return $this->teccc_settings;
+	}
+
+	private function do_color_settings_row( $option ) {
+		$slug = $option[ Main::SLUG ];
+		$name = $option[ Main::NAME ];
+
+		$this->teccc_settings[ "{$slug}_row_start" ] = [
+			'type' => 'html',
+			'html' => '<tr>',
+		];
+
+		$this->do_hide_cell( $slug, $name );
+
+		$this->do_slug_cell( $slug );
+
+		$this->do_border_cell( $slug, $name );
+
+		$this->do_background_cell( $slug, $name );
+
+		$this->do_text_cell( $slug, $name );
+
+		$this->do_current_display_cell( $slug, $name );
+
+		$this->teccc_settings[ "{$slug}_row_end" ] = [
+			'type' => 'html',
+			'html' => '</tr>',
+		];
+
+		return $this->teccc_settings;
+	}
+
+	private function generate_field_name( $slug, $field ) {
+		return esc_attr($slug) . '-' . esc_attr($field);
+	}
+
+	private function do_hide_cell( $slug, $name ) {
+
+		$this->teccc_settings[ $this->generate_field_name( $slug, 'hide_cell_start' ) ] = [
+			'type' => 'html',
+			'html' => '<td>',
+		];
+
+		$this->teccc_settings[ $this->generate_field_name( $slug, 'hide' ) ] = [
+			'type'            => 'checkbox_bool',
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+			'tooltip'         => sprintf(
+				esc_html__( 'Hides the %s category on the front end.', 'the-events-calendar-category-colors' ),
+				esc_html( $name )
+			),
+		];
+
+		add_filter( 'tribe_field_tooltip', function( $tooltip, $field ) use ( $slug ) {
+			if ( $this->generate_field_name( $slug, 'hide' ) === $field ) {
+				return false;
+			}
+
+			return $tooltip;
+		}, 10, 2 );
+
+		$this->teccc_settings[ $this->generate_field_name( $slug, 'hide_cell_end' ) ] = [
+			'type' => 'html',
+			'html' => '</td>',
+		];
+
+		// Unset these if the category is hidden;
+		if ( ! empty( $this->options['hide'][ $slug ] ) ) {
+			$this->options[ "{$slug}-border_none" ]     = '';
+			$this->options[ "{$slug}-background_none" ] = '';
+		}
+	}
+
+	private function do_slug_cell( $slug ) {
+		$this->teccc_settings[ "{$slug}_slug_cell" ] = [
+			'type' => 'html',
+			'html' => '<td>' . esc_html( $slug ) . '</td>',
+		];
+	}
+
+	private function do_border_cell(  $slug, $name ) {
+		$this->teccc_settings[ "{$slug}_border_cell_start" ] = [
+			'type' => 'html',
+			'html' => '<td class="color-control">',
+		];
+
+		$border_field_id = sanitize_title( $this->generate_field_name( $slug, 'border_none' ) );
+
+		$this->teccc_settings[  $this->generate_field_name( $slug, 'border_none' ) ] = [
+			'type'            => 'checkbox_bool',
+			'label'           => esc_html__( 'No Border', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+			'attributes'      => [ 'id' => $border_field_id ],
+		];
+
+		$this->teccc_settings[ $this->generate_field_name( $slug, 'border' ) ] = [
+			'type'                => 'text',
+			'label'               => esc_html__( 'Border Color', 'the-events-calendar-category-colors' ),
+			'class'               => 'color-selector',
+			'attributes'          => [ 'id' => $this->generate_field_name( $slug, 'border' ), 'class' => 'teccc-color-picker' ],
+			'validation_type'     => 'color',
+			'parent_option'       => 'teccc_options',
+			'can_be_empty'        => true,
+		];
+
+		$this->teccc_settings[ "{$slug}_border_cell_end" ] = [
+			'type' => 'html',
+			'html' => '</td>',
+		];
+	}
+
+	private function do_background_cell(  $slug, $name ) {
+		$this->teccc_settings[ "{$slug}_background_cell_start" ] = [
+			'type' => 'html',
+			'html' => '<td class="color-control">',
+		];
+
+		$background_field_id = sanitize_title( $this->generate_field_name( $slug, 'background_none' ) );
+
+		$this->teccc_settings[  $this->generate_field_name( $slug, 'background_none' ) ] = [
+			'type'            => 'checkbox_bool',
+			'label'           => esc_html__( 'No Background', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+			'attributes'      => [ 'id' => $background_field_id ],
+		];
+
+		$this->teccc_settings[ $this->generate_field_name( $slug, 'background' ) ] = [
+			'type'                => 'text',
+			'label'               => esc_html__( 'Background Color', 'the-events-calendar-category-colors' ),
+			'class'               => 'color-selector',
+			'validation_type'     => 'color',
+			'attributes'          => [ 'id' => $this->generate_field_name( $slug, 'background' ), 'class' => 'teccc-color-picker' ],
+			'can_be_empty'        => true,
+			'parent_option'       => 'teccc_options',
+		];
+
+		$this->teccc_settings[ $this->generate_field_name( $slug, 'background-color-selector' ) ] = [
+			'type' => 'html',
+			'html' => '<div class=""></div>',
+		];
+
+		$this->teccc_settings[ "{$slug}_background_cell_end" ] = [
+			'type' => 'html',
+			'html' => '</td>',
+		];
+	}
+
+	private function do_text_cell(  $slug, $name ) {
+		$this->teccc_settings[ "{$slug}_text_cell_start" ] = [
+			'type' => 'html',
+			'html' => '<td>',
+		];
+
+		$this->teccc_settings[ "{$slug}_text" ] = [
+			'type'            => 'dropdown',
+			'tooltip_first'   => true,
+			'tooltip'         => esc_html__( 'Text Color', 'the-events-calendar-category-colors' ),
+			'options'         => array_flip( $this->teccc->text_colors ),
+			'default'         => 'no_color',
+			'validation_type' => 'options',
+			'parent_option'   => 'teccc_options',
+			'can_be_empty'    => true,
+		];
+
+		$this->teccc_settings[ "{$slug}_text_cell_end" ] = [
+			'type' => 'html',
+			'html' => '</td>',
+		];
+	}
+
+	private function do_current_display_cell(  $slug, $name ) {
+		$style  = '';
+
+		if ( ! empty( $this->options[ "{$slug}-background" ] ) ) {
+			$option = $this->options[ "{$slug}-background" ];
+			$style .= "background-color: {$option};";
+		};
+
+		if ( ! empty( $this->options[ "{$slug}-border" ] ) ) {
+			$option = $this->options[ "{$slug}-border" ];
+			$style .= "border-left: 5px solid {$option};";
+		};
+
+		$text_color = $this->options[ "{$slug}-text" ]?? 'no_color';
+
+		if ( 'no_color' !== $text_color ) {
+			$option = $this->options[ "{$slug}-text" ];
+			$style .= "color: {$option};";
+		};
+
+		$option = $this->options[ 'font_weight' ]?? 'bold';
+		$style .= "border-right: 5px solid transparent; font-weight: {$option}; padding: 0.5em 1em;";
+
+		$this->teccc_settings[ "{$slug}_current_display_cell" ] = [
+			'type' => 'html',
+			'html' => '<td>' . esc_html( $name ) . '</td>',
+		];
+	}
+}
+
+/*
+
+			<tr>
+				<td  colspan="2">
+					<div><?php esc_html_e( 'Featured Event Color', 'the-events-calendar-category-colors' ); ?></div>
+				</td>
+				<td class="color-control">
+					<div class="transparency">
+						<label>
+							<input name="teccc_options[featured-event_none]" type="checkbox" value="1" <?php checked( '1', $options['featured-event_none'] ); ?> /> <?php esc_html_e( 'Transparent', 'the-events-calendar-category-colors' ); ?>
+						</label><br>
+						<?php
+						if ( '1' === $options['featured-event_none'] ) :
+							$options['featured-event'] = 'transparent';
+							?>
+						<?php endif ?>
+					</div>
+					<div class="color-selector">
+						<label>
+							<input class="teccc-color-picker" type="text" name="teccc_options[featured-event]" value="<?php echo esc_attr( $options['featured-event'] ); ?>" />
+						</label>
+					</div>
+				</td>
+				<td colspan="2">
+					<p><?php esc_html_e( 'Add right border for featured events.', 'the-events-calendar-category-colors' ); ?></p>
+				</td>
+			</tr>
+			<tr valign="top" style="border-top:#dddddd 1px solid;">
+				<td colspan="5"></td>
+			</tr>
+
+		</table>
+
+		<div id="teccc_options">
+
+			<div class="teccc_options_col1"> <?php esc_html_e( 'Font-Weight Options', 'the-events-calendar-category-colors' ); ?> </div>
+			<div class="teccc_options_col2">
+				<label> <select name="teccc_options[font_weight]" id="teccc_font_weight">
+						<?php foreach ( (array) $teccc->font_weights as $key => $value ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $options['font_weight'] ); ?>>
+								<?php esc_html_e( $key ); ?>
+							</option>
+						<?php endforeach ?>
+					</select> </label>
+			</div>
+
+			<div id="category_legend_checkboxes">
+				<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
+				<div id="category_legend_setting" class="teccc_options_col2">
+					<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array( 'month', $options['add_legend'], true ) ); ?>>
+					<label for="add_legend_month_view"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
+				</div>
+				<div id="category_legend_setting_list_view" class="teccc_options_col2">
+					<input id="add_legend_list_view" name="teccc_options[add_legend][]" type="checkbox" value="list" <?php checked( '1', in_array( 'list', $options['add_legend'], true ) ); ?>>
+					<label for="add_legend_list_view"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
+				</div>
+				<div id="category_legend_setting_day_view" class="teccc_options_col2">
+					<input id="add_legend_day_view" name="teccc_options[add_legend][]" type="checkbox" value="day" <?php checked( '1', in_array( 'day', $options['add_legend'], true ) ); ?>>
+					<label for="add_legend_day_view"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
+				</div>
+
+				<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
+				<div id="category_legend_setting_week_view" class="teccc_options_col2">
+					<input id="add_legend_week_view" name="teccc_options[add_legend][]" type="checkbox" value="week" <?php checked( '1', in_array( 'week', $options['add_legend'], true ) ); ?>>
+					<label for="add_legend_week_view"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
+				</div>
+				<div id="category_legend_setting_photo_view" class="teccc_options_col2">
+					<input id="add_legend_photo_view" name="teccc_options[add_legend][]" type="checkbox" value="photo" <?php checked( '1', in_array( 'photo', $options['add_legend'], true ) ); ?>>
+					<label for="add_legend_photo_view"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
+				</div>
+				<div id="category_legend_setting_map_view" class="teccc_options_col2">
+					<input id="add_legend_map_view" name="teccc_options[add_legend][]" type="checkbox" value="map" <?php checked( '1', in_array( 'map', $options['add_legend'], true ) ); ?>>
+					<label for="add_legend_map_view"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
+				</div>
+				<div id="category_legend_setting_summary_view" class="teccc_options_col2">
+					<input id="add_legend_summary_view" name="teccc_options[add_legend][]" type="checkbox" value="summary" <?php checked( '1', in_array( 'summary', $options['add_legend'], true ) ); ?>>
+					<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
+				</div>
+				<?php endif; ?>
+			</div>
+
+			<!-- Add Reset Button -->
+			<div id="legend_reset_button">
+			<div class="teccc_options_col1"> <?php esc_html_e( 'Reset Button', 'the-events-calendar-category-colors' ); ?> </div>
+			<div class="teccc_options_col2 legend_related_notice">
+				<?php esc_html_e( 'For this option you have to show the category legend at least on one view.', 'the-events-calendar-category-colors' ); ?>
+			</div>
+			<div class="teccc_options_col2 legend_related">
+				<input id="teccc_options_reset_show" name="teccc_options[reset_show]" type="checkbox" value="1" <?php checked( '1', $options['reset_show'] ); ?> />
+				<label for="teccc_options_reset_show"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
+			</div>
+			<div class="teccc_options_col2 legend_related">
+				<input id="teccc_options_reset_label" name="teccc_options[reset_label]" type="text" placeholder="<?php esc_html_e( 'Reset', 'the-events-calendar-category-colors' ); ?>" value="<?php echo esc_attr( $options['reset_label'] ); ?>" />
+				<label for="teccc_options_reset_label"><?php esc_html_e( 'Reset button label', 'the-events-calendar-category-colors' ); ?></label>
+			</div>
+			<div class="teccc_options_col2 legend_related">
+				<input id="teccc_options_reset_url" name="teccc_options[reset_url]" type="text" placeholder="<?php echo esc_attr( tribe_get_events_link() ); ?>" value="<?php echo esc_attr( $options['reset_url'] ); ?>" />
+				<label for="teccc_options_reset_url"><?php esc_html_e( 'Reset button URL', 'the-events-calendar-category-colors' ); ?></label>
+				<p><?php esc_html_e( 'By default the reset button will point to the default calendar URL.', 'the-events-calendar-category-colors' ); ?></p>
+			</div>
+			</div>
+
+			<!-- Add Legend Superpowers -->
+			<div id="category_legend_superpowers">
+			<div class="teccc_options_col1"> <?php esc_html_e( 'Legend Superpowers', 'the-events-calendar-category-colors' ); ?> </div>
+			<div class="teccc_options_col2 legend_related_notice">
+				<?php esc_html_e( 'For this option you have to show the category legend at least on one view.', 'the-events-calendar-category-colors' ); ?>
+			</div>
+			<div class="teccc_options_col2 legend_related legend_superpowers">
+				<label>
+					<input name="teccc_options[legend_superpowers]" type="checkbox" value="1" <?php checked( '1', $options['legend_superpowers'] ); ?> /> <?php esc_html_e( 'Check to add Legend Superpowers.', 'the-events-calendar-category-colors' ); ?>
+				</label>
+				<p><?php esc_html_e( 'Legend Superpowers are an optional visual effect allowing visitors to focus only on those events that belong to categories of interest - without reloading the page and without eliminating other categories from view completely. Click on the category of interest in the Legend for the effect; click again to remove it.', 'the-events-calendar-category-colors' ); ?> </p>
+			</div>
+
+			<div class="teccc_options_col1 legend_related legend_related_superpowers"><!-- Show Hidden Categories --></div>
+			<div class="teccc_options_col2 legend_related legend_related_superpowers">
+				<label>
+					<input name="teccc_options[show_ignored_cats_legend]" type="checkbox" value="1" <?php checked( '1', $options['show_ignored_cats_legend'] ); ?> /> <?php esc_html_e( 'Show hidden categories in legend.', 'the-events-calendar-category-colors' ); ?>
+				</label>
+			</div>
+
+			<div class="teccc_options_col1 legend_related legend_related_superpowers"><!-- Custom Legend CSS --></div>
+			<div class="teccc_options_col2 legend_related legend_related_superpowers">
+				<label>
+					<input name="teccc_options[custom_legend_css]" type="checkbox" value="1" <?php checked( '1', $options['custom_legend_css'] ); ?> /> <?php esc_html_e( 'Check to use your own CSS for category legend.', 'the-events-calendar-category-colors' ); ?>
+				</label>
+			</div>
+			</div>
+
+			<div class="teccc_options_col1"> <?php esc_html_e( 'Database Options', 'the-events-calendar-category-colors' ); ?> </div>
+			<div class="teccc_options_col2">
+				<label>
+					<input name="teccc_options[chk_default_options_db]" type="checkbox" value="1" <?php checked( '1', $options['chk_default_options_db'] ); ?> /> <?php esc_html_e( 'Restore defaults upon plugin deactivation/reactivation', 'the-events-calendar-category-colors' ); ?>
+				</label>
+				<p> <?php esc_html_e( 'Only check this if you want to reset plugin settings upon Plugin reactivation', 'the-events-calendar-category-colors' ); ?> </p>
+			</div>
+
+		</div>
+*/

--- a/src/Category_Colors/Settings.php
+++ b/src/Category_Colors/Settings.php
@@ -7,6 +7,8 @@
 
 namespace Fragen\Category_Colors;
 
+use Tribe\Events\Views\V2\Manager;
+
 /**
  * Settings class.
  *
@@ -79,21 +81,33 @@ class Settings {
 		];
 
 
-		foreach ( (array) $this->teccc->all_terms as $option ) {
-			$this->do_color_settings_row( $option );
+		foreach ( (array) $this->teccc->all_terms as $term ) {
+			$this->do_color_settings_row( $term );
 		}
+
+		$this->do_featured_event_row();
 
 		$this->teccc_settings['tec_category_colors_table_end'] = [
 			'type' => 'html',
 			'html' => '</table>',
 		];
 
+		$this->do_additional_options();
+
 		return $this->teccc_settings;
 	}
 
-	private function do_color_settings_row( $option ) {
-		$slug = $option[ Main::SLUG ];
-		$name = $option[ Main::NAME ];
+	/**
+	 * Output a color settings row.
+	 *
+	 * @since TBD
+	 *
+	 * @param [type] $option
+	 * @return void
+	 */
+	private function do_color_settings_row( $term ) {
+		$slug = $term[ Main::SLUG ];
+		$name = $term[ Main::NAME ];
 
 		$this->teccc_settings[ "{$slug}_row_start" ] = [
 			'type' => 'html',
@@ -120,10 +134,28 @@ class Settings {
 		return $this->teccc_settings;
 	}
 
-	private function generate_field_name( $slug, $field ) {
-		return esc_attr($slug) . '-' . esc_attr($field);
+	/**
+	 * Generate a field name.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The category slug.
+	 * @param string $field The field name.
+	 */
+	private function generate_field_name( $slug, $field ): string {
+		return esc_attr( $slug ) . '-' . esc_attr( $field );
 	}
 
+	/**
+	 * Output the "hide" cell.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The category slug.
+	 * @param string $field The field name.
+	 *
+	 * @return void
+	 */
 	private function do_hide_cell( $slug, $name ) {
 
 		$this->teccc_settings[ $this->generate_field_name( $slug, 'hide_cell_start' ) ] = [
@@ -131,7 +163,7 @@ class Settings {
 			'html' => '<td>',
 		];
 
-		$this->teccc_settings[ $this->generate_field_name( $slug, 'hide' ) ] = [
+		$this->teccc_settings[ "hide[{$slug}]" ] = [
 			'type'            => 'checkbox_bool',
 			'default'         => false,
 			'validation_type' => 'boolean',
@@ -162,6 +194,14 @@ class Settings {
 		}
 	}
 
+	/**
+	 * Output the slug display cell.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The category slug.
+	 * @return void
+	 */
 	private function do_slug_cell( $slug ) {
 		$this->teccc_settings[ "{$slug}_slug_cell" ] = [
 			'type' => 'html',
@@ -169,6 +209,16 @@ class Settings {
 		];
 	}
 
+	/**
+	 * Output the border color cell.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The category slug.
+	 * @param string $name  The category name.
+	 *
+	 * @return void
+	 */
 	private function do_border_cell(  $slug, $name ) {
 		$this->teccc_settings[ "{$slug}_border_cell_start" ] = [
 			'type' => 'html',
@@ -179,7 +229,8 @@ class Settings {
 
 		$this->teccc_settings[  $this->generate_field_name( $slug, 'border_none' ) ] = [
 			'type'            => 'checkbox_bool',
-			'label'           => esc_html__( 'No Border', 'the-events-calendar-category-colors' ),
+			'label'           => '',
+			'tooltip'         => esc_html__( 'No Border', 'the-events-calendar-category-colors' ),
 			'default'         => false,
 			'validation_type' => 'boolean',
 			'parent_option'   => 'teccc_options',
@@ -188,7 +239,8 @@ class Settings {
 
 		$this->teccc_settings[ $this->generate_field_name( $slug, 'border' ) ] = [
 			'type'                => 'text',
-			'label'               => esc_html__( 'Border Color', 'the-events-calendar-category-colors' ),
+			'label'               => '',
+			'tooltip'             => esc_html__( 'Border Color', 'the-events-calendar-category-colors' ),
 			'class'               => 'color-selector',
 			'attributes'          => [ 'id' => $this->generate_field_name( $slug, 'border' ), 'class' => 'teccc-color-picker' ],
 			'validation_type'     => 'color',
@@ -202,6 +254,16 @@ class Settings {
 		];
 	}
 
+	/**
+	 * Output the background color cell.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The category slug.
+	 * @param string $name  The category name.
+	 *
+	 * @return void
+	 */
 	private function do_background_cell(  $slug, $name ) {
 		$this->teccc_settings[ "{$slug}_background_cell_start" ] = [
 			'type' => 'html',
@@ -212,7 +274,8 @@ class Settings {
 
 		$this->teccc_settings[  $this->generate_field_name( $slug, 'background_none' ) ] = [
 			'type'            => 'checkbox_bool',
-			'label'           => esc_html__( 'No Background', 'the-events-calendar-category-colors' ),
+			'label'           => '',
+			'tooltip'         => esc_html__( 'No Background', 'the-events-calendar-category-colors' ),
 			'default'         => false,
 			'validation_type' => 'boolean',
 			'parent_option'   => 'teccc_options',
@@ -221,17 +284,13 @@ class Settings {
 
 		$this->teccc_settings[ $this->generate_field_name( $slug, 'background' ) ] = [
 			'type'                => 'text',
-			'label'               => esc_html__( 'Background Color', 'the-events-calendar-category-colors' ),
+			'label'               => '',
+			'tooltip'             => esc_html__( 'Background Color', 'the-events-calendar-category-colors' ),
 			'class'               => 'color-selector',
 			'validation_type'     => 'color',
 			'attributes'          => [ 'id' => $this->generate_field_name( $slug, 'background' ), 'class' => 'teccc-color-picker' ],
 			'can_be_empty'        => true,
 			'parent_option'       => 'teccc_options',
-		];
-
-		$this->teccc_settings[ $this->generate_field_name( $slug, 'background-color-selector' ) ] = [
-			'type' => 'html',
-			'html' => '<div class=""></div>',
 		];
 
 		$this->teccc_settings[ "{$slug}_background_cell_end" ] = [
@@ -240,6 +299,16 @@ class Settings {
 		];
 	}
 
+	/**
+	 * Output the text color cell.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The category slug.
+	 * @param string $name  The category name.
+	 *
+	 * @return void
+	 */
 	private function do_text_cell(  $slug, $name ) {
 		$this->teccc_settings[ "{$slug}_text_cell_start" ] = [
 			'type' => 'html',
@@ -253,6 +322,7 @@ class Settings {
 			'options'         => array_flip( $this->teccc->text_colors ),
 			'default'         => 'no_color',
 			'validation_type' => 'options',
+			'size'            => 'small',
 			'parent_option'   => 'teccc_options',
 			'can_be_empty'    => true,
 		];
@@ -263,6 +333,16 @@ class Settings {
 		];
 	}
 
+	/**
+	 * Output the current display cell. This is a live demo of the row settings.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug  The category slug.
+	 * @param string $name  The category name.
+	 *
+	 * @return void
+	 */
 	private function do_current_display_cell(  $slug, $name ) {
 		$style  = '';
 
@@ -291,109 +371,182 @@ class Settings {
 			'html' => '<td>' . esc_html( $name ) . '</td>',
 		];
 	}
+
+	/**
+	 * Output the featured event row.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function do_featured_event_row() {
+		$this->teccc_settings[ 'featured_event_row_start' ] = [
+			'type' => 'html',
+			'html' => '<tr>',
+		];
+
+		$this->teccc_settings[ 'featured_event_cell_start' ] = [
+			'type' => 'html',
+			'html' => '<td colspan="2">',
+		];
+
+		$this->teccc_settings[ 'featured_event_label' ] = [
+			'type' => 'html',
+			'html' => '<div>' . esc_html__( 'Featured Event Color', 'the-events-calendar-category-colors' ) . '</div>',
+		];
+
+		$this->teccc_settings[ 'featured_event_cell_end' ] = [
+			'type' => 'html',
+			'html' => '</td>',
+		];
+
+		$this->teccc_settings[ 'featured_event_color_control_start' ] = [
+			'type' => 'html',
+			'html' => '<td class="color-control" colspan="2">',
+		];
+
+		$featured_border_field_id = sanitize_title( 'featured-event_none' );
+
+		$this->teccc_settings[  'featured-event_none' ] = [
+			'type'            => 'checkbox_bool',
+			'label'           => '',//
+			'tooltip'         => esc_html__( 'Transparent', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+			'attributes'      => [ 'id' => $featured_border_field_id ],
+		];
+
+		$this->teccc_settings[ 'featured-event' ] = [
+			'type'                => 'text',
+			'label'               => '',
+			'class'               => 'color-selector',
+			'attributes'          => [ 'id' => 'featured-event', 'class' => 'teccc-color-picker' ],
+			'validation_type'     => 'color',
+			'parent_option'       => 'teccc_options',
+			'tooltip'             => esc_html__( 'Add right border for featured events.', 'the-events-calendar-category-colors' ),
+			'can_be_empty'        => true,
+		];
+
+		$this->teccc_settings[ 'featured_event_color_control_end' ] = [
+			'type' => 'html',
+			'html' => '</td>',
+		];
+	}
+
+	/**
+	 * Output the additional options.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	private function do_additional_options() {
+		$this->teccc_settings['additional_options_title'] = [
+		'type' => 'html',
+		'html' => '<h3 id="teccc-settings-additional-options" class="tec-settings-form__section-header">' . esc_html_x( 'Additional Options', 'Additional options settings section header', 'the-events-calendar-category-colors' ) . '</h3>',
+		];
+
+		$this->teccc_settings['font_weight'] = [
+			'type'            => 'dropdown',
+			'label'           => __( 'Font-Weight Options', 'the-events-calendar-category-colors' ),
+			'tooltip'         => __( 'Choose the font weight for the category legend.', 'the-events-calendar-category-colors' ),
+			'options'         => $this->teccc->font_weights,
+			'attributes'      => [ 'id' => 'teccc_font_weight' ],
+			'parent_option'   => 'teccc_options',
+		];
+
+		$this->teccc_settings['add_legend'] = [
+			'type'          => 'checkbox_list',
+			'label'         => __( 'Show Category Legend', 'the-events-calendar-category-colors' ),
+			'tooltip'       => __( 'Choose where to show the category legend.', 'the-events-calendar-category-colors' ),
+			'parent_option' => 'teccc_options',
+			'options'       => array_map(
+				static function ( $view ) {
+					return tribe( Manager::class )->get_view_label_by_class( $view );
+				},
+				tribe( Manager::class )->get_publicly_visible_views( false )
+			),
+		];
+
+		$this->teccc_settings['reset_options_title'] = [
+			'type' => 'html',
+			'html' => '<h3 id="teccc-settings-additional-options" class="tec-settings-form__section-header">' . esc_html_x( 'Reset Options', 'Reset options settings section header', 'the-events-calendar-category-colors' ) . '</h3>',
+		];
+
+		$this->teccc_settings['reset_show'] = [
+			'type'            => 'checkbox_bool',
+			'label'           => __( 'Show Reset Button', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+		];
+
+		$this->teccc_settings['reset_label'] = [
+			'type'            => 'text',
+			'label'           => __( 'Reset Button Label', 'the-events-calendar-category-colors' ),
+			'parent_option'   => 'teccc_options',
+
+		];
+
+		$this->teccc_settings['reset_url'] = [
+			'type'            => 'text',
+			'label'           => __( 'Reset Button URL', 'the-events-calendar-category-colors' ),
+			'tooltip'         => __( 'By default the reset button will point to the default calendar URL.', 'the-events-calendar-category-colors' ),
+			'placeholder'     => tribe_get_events_link(),
+			'parent_option'   => 'teccc_options',
+		];
+
+		$this->teccc_settings['legend_superpowers_options_title'] = [
+			'type' => 'html',
+			'html' => '<h3 id="teccc-settings-legend-superpowers-options" class="tec-settings-form__section-header">' . esc_html_x( 'Legend Superpowers', 'Legend Superpowers settings section header', 'the-events-calendar-category-colors' ) . '</h3>',
+			];
+
+		$this->teccc_settings['legend_superpowers'] = [
+			'type'            => 'checkbox_bool',
+			'label'           => __( 'Legend Superpowers', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+		];
+
+		$this->teccc_settings['show_ignored_cats_legend'] = [
+			'type'            => 'checkbox_bool',
+			'label'           => __( 'Show hidden categories in legend', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+		];
+
+		$this->teccc_settings['custom_legend_css'] = [
+			'type'            => 'checkbox_bool',
+			'label'           => __( 'Check to use your own CSS for category legend', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+		];
+
+		$this->teccc_settings['database_options_title'] = [
+			'type' => 'html',
+			'html' => '<h3 id="teccc-settings-database-options" class="tec-settings-form__section-header">' . esc_html_x( 'Database Options', 'Database options settings section header', 'the-events-calendar-category-colors' ) . '</h3>',
+		];
+
+		$this->teccc_settings['chk_default_options_db'] = [
+			'type'            => 'checkbox_bool',
+			'label'           => __( 'Restore defaults upon plugin deactivation/reactivation', 'the-events-calendar-category-colors' ),
+			'tooltip'         => __( 'Only check this if you want to reset plugin settings upon Plugin reactivation!', 'the-events-calendar-category-colors' ),
+			'default'         => false,
+			'validation_type' => 'boolean',
+			'parent_option'   => 'teccc_options',
+		];
+	}
 }
 
 /*
 
-			<tr>
-				<td  colspan="2">
-					<div><?php esc_html_e( 'Featured Event Color', 'the-events-calendar-category-colors' ); ?></div>
-				</td>
-				<td class="color-control">
-					<div class="transparency">
-						<label>
-							<input name="teccc_options[featured-event_none]" type="checkbox" value="1" <?php checked( '1', $options['featured-event_none'] ); ?> /> <?php esc_html_e( 'Transparent', 'the-events-calendar-category-colors' ); ?>
-						</label><br>
-						<?php
-						if ( '1' === $options['featured-event_none'] ) :
-							$options['featured-event'] = 'transparent';
-							?>
-						<?php endif ?>
-					</div>
-					<div class="color-selector">
-						<label>
-							<input class="teccc-color-picker" type="text" name="teccc_options[featured-event]" value="<?php echo esc_attr( $options['featured-event'] ); ?>" />
-						</label>
-					</div>
-				</td>
-				<td colspan="2">
-					<p><?php esc_html_e( 'Add right border for featured events.', 'the-events-calendar-category-colors' ); ?></p>
-				</td>
-			</tr>
-			<tr valign="top" style="border-top:#dddddd 1px solid;">
-				<td colspan="5"></td>
-			</tr>
-
-		</table>
-
 		<div id="teccc_options">
 
-			<div class="teccc_options_col1"> <?php esc_html_e( 'Font-Weight Options', 'the-events-calendar-category-colors' ); ?> </div>
-			<div class="teccc_options_col2">
-				<label> <select name="teccc_options[font_weight]" id="teccc_font_weight">
-						<?php foreach ( (array) $teccc->font_weights as $key => $value ) : ?>
-							<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $options['font_weight'] ); ?>>
-								<?php esc_html_e( $key ); ?>
-							</option>
-						<?php endforeach ?>
-					</select> </label>
-			</div>
 
-			<div id="category_legend_checkboxes">
-				<div class="teccc_options_col1"> <?php esc_html_e( 'Show Category Legend', 'the-events-calendar-category-colors' ); ?> </div>
-				<div id="category_legend_setting" class="teccc_options_col2">
-					<input id="add_legend_month_view" name="teccc_options[add_legend][]" type="checkbox" value="month" <?php checked( 1, in_array( 'month', $options['add_legend'], true ) ); ?>>
-					<label for="add_legend_month_view"><?php esc_html_e( 'Month view', 'the-events-calendar-category-colors' ); ?></label>
-				</div>
-				<div id="category_legend_setting_list_view" class="teccc_options_col2">
-					<input id="add_legend_list_view" name="teccc_options[add_legend][]" type="checkbox" value="list" <?php checked( '1', in_array( 'list', $options['add_legend'], true ) ); ?>>
-					<label for="add_legend_list_view"><?php esc_html_e( 'List view', 'the-events-calendar-category-colors' ); ?></label>
-				</div>
-				<div id="category_legend_setting_day_view" class="teccc_options_col2">
-					<input id="add_legend_day_view" name="teccc_options[add_legend][]" type="checkbox" value="day" <?php checked( '1', in_array( 'day', $options['add_legend'], true ) ); ?>>
-					<label for="add_legend_day_view"><?php esc_html_e( 'Day view', 'the-events-calendar-category-colors' ); ?></label>
-				</div>
-
-				<?php if ( class_exists( 'Tribe__Events__Pro__Main' ) ) : ?>
-				<div id="category_legend_setting_week_view" class="teccc_options_col2">
-					<input id="add_legend_week_view" name="teccc_options[add_legend][]" type="checkbox" value="week" <?php checked( '1', in_array( 'week', $options['add_legend'], true ) ); ?>>
-					<label for="add_legend_week_view"><?php esc_html_e( 'Week view', 'the-events-calendar-category-colors' ); ?></label>
-				</div>
-				<div id="category_legend_setting_photo_view" class="teccc_options_col2">
-					<input id="add_legend_photo_view" name="teccc_options[add_legend][]" type="checkbox" value="photo" <?php checked( '1', in_array( 'photo', $options['add_legend'], true ) ); ?>>
-					<label for="add_legend_photo_view"><?php esc_html_e( 'Photo view', 'the-events-calendar-category-colors' ); ?></label>
-				</div>
-				<div id="category_legend_setting_map_view" class="teccc_options_col2">
-					<input id="add_legend_map_view" name="teccc_options[add_legend][]" type="checkbox" value="map" <?php checked( '1', in_array( 'map', $options['add_legend'], true ) ); ?>>
-					<label for="add_legend_map_view"><?php esc_html_e( 'Map view', 'the-events-calendar-category-colors' ); ?></label>
-				</div>
-				<div id="category_legend_setting_summary_view" class="teccc_options_col2">
-					<input id="add_legend_summary_view" name="teccc_options[add_legend][]" type="checkbox" value="summary" <?php checked( '1', in_array( 'summary', $options['add_legend'], true ) ); ?>>
-					<label for="add_legend_summary_view"><?php esc_html_e( 'Summary view', 'the-events-calendar-category-colors' ); ?></label>
-				</div>
-				<?php endif; ?>
-			</div>
-
-			<!-- Add Reset Button -->
-			<div id="legend_reset_button">
-			<div class="teccc_options_col1"> <?php esc_html_e( 'Reset Button', 'the-events-calendar-category-colors' ); ?> </div>
-			<div class="teccc_options_col2 legend_related_notice">
-				<?php esc_html_e( 'For this option you have to show the category legend at least on one view.', 'the-events-calendar-category-colors' ); ?>
-			</div>
-			<div class="teccc_options_col2 legend_related">
-				<input id="teccc_options_reset_show" name="teccc_options[reset_show]" type="checkbox" value="1" <?php checked( '1', $options['reset_show'] ); ?> />
-				<label for="teccc_options_reset_show"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
-			</div>
-			<div class="teccc_options_col2 legend_related">
-				<input id="teccc_options_reset_label" name="teccc_options[reset_label]" type="text" placeholder="<?php esc_html_e( 'Reset', 'the-events-calendar-category-colors' ); ?>" value="<?php echo esc_attr( $options['reset_label'] ); ?>" />
-				<label for="teccc_options_reset_label"><?php esc_html_e( 'Reset button label', 'the-events-calendar-category-colors' ); ?></label>
-			</div>
-			<div class="teccc_options_col2 legend_related">
-				<input id="teccc_options_reset_url" name="teccc_options[reset_url]" type="text" placeholder="<?php echo esc_attr( tribe_get_events_link() ); ?>" value="<?php echo esc_attr( $options['reset_url'] ); ?>" />
-				<label for="teccc_options_reset_url"><?php esc_html_e( 'Reset button URL', 'the-events-calendar-category-colors' ); ?></label>
-				<p><?php esc_html_e( 'By default the reset button will point to the default calendar URL.', 'the-events-calendar-category-colors' ); ?></p>
-			</div>
-			</div>
 
 			<!-- Add Legend Superpowers -->
 			<div id="category_legend_superpowers">

--- a/src/functions/admintab.php
+++ b/src/functions/admintab.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 
@@ -13,48 +13,38 @@
  */
 namespace Fragen\Category_Colors;
 
-return [
+use Fragen\Category_Colors\Settings as Settings;
+
+$settings = [
 	'priority'      => 40,
-	'show_save'     => false,
-	'parent_option' => 'teccc_options',
 	'fields'        => [
-		'info-start'         => [
+		'tec-settings-category-colors-title' => [
 			'type' => 'html',
-			'html' => '<div id="modern-tribe-info">',
+			'html' => '<div class="tec-settings-form__header-block tec-settings-form__header-block--horizontal">'
+					. '<h3 id="tec-settings-category-colors-title" class="tec-settings-form__section-header">'
+					. _x( 'Category Colors Settings', 'Title for the category colors tab.', 'the-events-calendar-category-colors' )
+					. '</h3>'
+					. '<p>' . sprintf(
+						wp_kses_post(
+							__( 'The Events Calendar: Category Colors plugin was inspired by the tutorial <i>Coloring Your Category Events</i>.', 'the-events-calendar-category-colors' )
+						)
+					) . '</p>'
+					.'<p>' . sprintf(
+						wp_kses_post( __( 'Instructions for <strong>filters</strong>, <strong>hooks</strong>, <strong>settings functions</strong>, and <strong>help</strong> are on <a href="https://github.com/the-events-calendar/the-events-calendar-category-colors/wiki">The Events Calendar: Category Colors wiki</a>.', 'the-events-calendar-category-colors' ) )
+					) . '</p>'
+					. '</div>',
 		],
-		'title'              => [
-			'type' => 'html',
-			'html' => '<h2>' . esc_html__( 'Category Colors Settings', 'the-events-calendar-category-colors' ) . '</h2>',
-		],
-		'blurb'              => [
-			'type' => 'html',
-			'html' => '<p>' . sprintf(
-				wp_kses_post(
-					__( 'The Events Calendar: Category Colors plugin was inspired by the tutorial <i>Coloring Your Category Events</i>.', 'the-events-calendar-category-colors' )
-				)
-			) . '</p>',
-		],
-		'legend'             => [
-			'type' => 'html',
-			'html' => '<p>' . sprintf(
-				wp_kses_post( __( 'Instructions for <strong>filters</strong>, <strong>hooks</strong>, <strong>settings functions</strong>, and <strong>help</strong> are on <a href="https://github.com/afragen/the-events-calendar-category-colors/wiki">The Events Calendar: Category Colors wiki</a>.', 'the-events-calendar-category-colors' ) )
-			) . '</p>',
-		],
-		'info-end'           => [
-			'type' => 'html',
-			'html' => '</div>',
-		],
-		'form-elements'      => [
-			'type' => 'html',
-			'html' => Admin::options_elements(),
-		],
-		'minicolors-console' => [
-			'type' => 'html',
-			'html' => '<div id="console"></div>',
-		],
-		'save-button'        => [
-			'type' => 'html',
-			'html' => '<p class="submit"><input type="submit" class="button-primary" value="' . esc_html__( 'Save Changes', 'the-events-calendar-category-colors' ) . '" /></p>',
-		],
+
 	],
 ];
+
+$settings_obj       = new Settings();
+$settings_fields    = $settings_obj->do_settings();
+$settings['fields'] = array_merge( $settings['fields'], $settings_fields );
+
+$settings['fields']['minicolors-console'] = [
+	'type' => 'html',
+	'html' => '<div id="console"></div>',
+];
+
+return $settings;

--- a/src/functions/templatetags.php
+++ b/src/functions/templatetags.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 
@@ -18,7 +18,7 @@
  * @deprecated 6.8.4.3
  */
 function teccc_remove_default_legend() {
-	_doing_it_wrong( 'teccc_remove_default_legend', esc_html__( 'Use of this function is deprecated .', 'the-events-calendar-category-colors' ), '6.4.8.3' );
+	_deprecated_function( __FUNCTION__, '6.4.8.3' );
 }
 
 
@@ -34,7 +34,7 @@ function teccc_remove_default_legend() {
  * @deprecated 6.4.8.3
  */
 function teccc_reposition_legend() {
-	_doing_it_wrong( 'teccc_reposition_legend', esc_html__( 'Use of this function is deprecated.', 'the-events-calendar-category-colors' ), '6.4.8.3' );
+	_deprecated_function( __FUNCTION__, '6.4.8.3' );
 }
 
 
@@ -45,18 +45,6 @@ function teccc_reposition_legend() {
 function teccc_insert_legend() {
 	Fragen\Category_Colors\Main::instance()->public->show_legend();
 }
-
-
-/**
- * An alias for teccc_insert_legend() - this function is deprecated and it is
- * preferred to call teccc_insert_legend() directly.
- *
- * @deprecated 1.6.0B
- */
-function teccc_legend_hook() {
-	_doing_it_wrong( 'teccc_legend_hook', esc_html__( 'Use of this function is deprecated, use `teccc_insert_legend()`', 'the-events-calendar-category-colors' ), '1.6.0B' );
-}
-
 
 /**
  * Registers an additional text color.

--- a/src/resources/teccc-admin.js
+++ b/src/resources/teccc-admin.js
@@ -60,7 +60,7 @@ jQuery( document ).ready(
 		 * too).
 		 */
 		function toggleColorControls() {
-			let colorSelector = $( this ).parents( "td" ).find( ".colorselector" );
+			let colorSelector = $( this ).parents( "td" ).find( ".color-selector" );
 
 			if ($( this ).prop( "checked" )) {
 				$( colorSelector ).slideUp();

--- a/src/resources/teccc-options.css
+++ b/src/resources/teccc-options.css
@@ -21,6 +21,21 @@
 	margin-left: 1em;
 }
 
+table.teccc.form-table {
+	margin: 0;
+}
+
 table.teccc.form-table td {
-	vertical-align: top;
+	vertical-align: text-top;
+}
+
+table.teccc.form-table th {
+	font-weight: var(--tec-font-weight-bold);
+	font-size: var(--tec-font-size-1);
+}
+
+@media screen and (min-width: 1024px) {
+	table.teccc.form-table {
+		margin-left: var(--tec-spacer-7);
+	}
 }

--- a/src/resources/teccc-options.css
+++ b/src/resources/teccc-options.css
@@ -23,16 +23,64 @@
 
 table.teccc.form-table {
 	margin: 0;
+	padding-left: var(--tec-spacer-settings-form-right-gap);
 }
 
 table.teccc.form-table td {
-	vertical-align: text-top;
+	vertical-align: middle;
+}
+table.teccc.form-table td:nth-child(5) {
+    vertical-align: bottom;
 }
 
 table.teccc.form-table th {
 	font-weight: var(--tec-font-weight-bold);
 	font-size: var(--tec-font-size-1);
+	text-align: center;
 }
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table .tribe-field-label {
+	display: inline-block;
+	font-weight: var(--tec-font-weight-regular);
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table .tribe-field-wrap {
+	display: inline-block;
+}
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table .tooltip {
+	text-wrap: nowrap;
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table .color-selector .tooltip {
+	display: none;
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table #tribe-field-featured-event .tooltip {
+	display: block;
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table fieldset {
+	margin-left: 0;
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table .tribe-field-checkbox_bool input[type="checkbox"] {
+	margin-top: 0;
+	vertical-align: text-bottom;
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table .tribe-field-checkbox_bool .tribe-field-wrap {
+	margin-bottom: var(--tec-spacer-2);
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table td:first-child .tribe-field-checkbox_bool .tribe-field-wrap {
+	margin-bottom: 0;
+}
+
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table fieldset[id$="_text"] .tooltip {
+	display: none;
+}
+
+// .tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table .color-selector:not['#tribe-field-featured-event'] .tooltip {
 
 @media screen and (min-width: 1024px) {
 	table.teccc.form-table {

--- a/src/resources/teccc-options.css
+++ b/src/resources/teccc-options.css
@@ -76,6 +76,10 @@ table.teccc.form-table th {
 	margin-bottom: 0;
 }
 
+.tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table td:first-child .tooltip {
+	display: none;
+}
+
 .tribe_events_page_tec-events-settings #tec-settings-form table.teccc.form-table fieldset[id$="_text"] .tooltip {
 	display: none;
 }

--- a/src/views/category.css.php
+++ b/src/views/category.css.php
@@ -17,7 +17,7 @@ use Fragen\Category_Colors\CSS\Pro;
 use Fragen\Category_Colors\CSS\V2_Views;
 
 ?>
-/* The Events Calendar: Category Colors <?php echo esc_html( Main::$version ); ?> */
+
 .teccc-legend a, .tribe-events-calendar a, #tribe-events-content .tribe-events-tooltip h4
 {
 	font-weight: <?php echo esc_attr( $options['font_weight'] ); ?>;

--- a/src/views/category.css.php
+++ b/src/views/category.css.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/views/legend.css.php
+++ b/src/views/legend.css.php
@@ -9,28 +9,29 @@
  */
 
 ?>
+<style>
+	#legend_box
+	{
+		font: bold 10px/4em sans-serif;
+		text-align: center;
+		width: 100%;
+	}
 
-#legend_box
-{
-	font: bold 10px/4em sans-serif;
-	text-align: center;
-	width: 100%;
-}
+	#legend a { text-decoration: none; }
 
-#legend a { text-decoration: none; }
+	#tribe-events #legend li, .tribe-events #legend li
+	{
+		display: inline-block;
+		list-style-type: none;
+		padding: 7px;
+		margin: 0 0 1em 0.7em;
+	}
 
-#tribe-events #legend li, .tribe-events #legend li
-{
-	display: inline-block;
-	list-style-type: none;
-	padding: 7px;
-	margin: 0 0 1em 0.7em;
-}
+	#legend_box #legend li span { cursor: pointer; }
 
-#legend_box #legend li span { cursor: pointer; }
-
-#tribe-events #legend li.teccc-reset,
-.tribe-events #legend li.teccc-reset
-{
-	line-height: 1.4px;
-}
+	#tribe-events #legend li.teccc-reset,
+	.tribe-events #legend li.teccc-reset
+	{
+		line-height: 1.4px;
+	}
+</style>

--- a/src/views/legend.css.php
+++ b/src/views/legend.css.php
@@ -9,7 +9,6 @@
  */
 
 ?>
-<style>
 	#legend_box
 	{
 		font: bold 10px/4em sans-serif;
@@ -34,4 +33,3 @@
 	{
 		line-height: 1.4px;
 	}
-</style>

--- a/src/views/legend.css.php
+++ b/src/views/legend.css.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/views/legend.css.php
+++ b/src/views/legend.css.php
@@ -9,27 +9,27 @@
  */
 
 ?>
-	#legend_box
-	{
-		font: bold 10px/4em sans-serif;
-		text-align: center;
-		width: 100%;
-	}
+#legend_box
+{
+	font: bold 10px/4em sans-serif;
+	text-align: center;
+	width: 100%;
+}
 
-	#legend a { text-decoration: none; }
+#legend a { text-decoration: none; }
 
-	#tribe-events #legend li, .tribe-events #legend li
-	{
-		display: inline-block;
-		list-style-type: none;
-		padding: 7px;
-		margin: 0 0 1em 0.7em;
-	}
+#tribe-events #legend li, .tribe-events #legend li
+{
+	display: inline-block;
+	list-style-type: none;
+	padding: 7px;
+	margin: 0 0 1em 0.7em;
+}
 
-	#legend_box #legend li span { cursor: pointer; }
+#legend_box #legend li span { cursor: pointer; }
 
-	#tribe-events #legend li.teccc-reset,
-	.tribe-events #legend li.teccc-reset
-	{
-		line-height: 1.4px;
-	}
+#tribe-events #legend li.teccc-reset,
+.tribe-events #legend li.teccc-reset
+{
+	line-height: 1.4px;
+}

--- a/src/views/legend.php
+++ b/src/views/legend.php
@@ -59,11 +59,11 @@ $terms = apply_filters( 'teccc_legend_terms', $teccc->terms );
 			<?php endforeach ?>
 		<?php endif ?>
 
-		<?php if ( isset( $options['reset_show'] ) && empty( $options['legend_superpowers'] ) ) : ?>
+		<?php if ( ! empty( $options['reset_show'] ) && empty( $options['legend_superpowers'] ) ) : ?>
 			<li class="teccc-reset">
 				<a href="
 				<?php
-				if ( ! isset( $options['reset_url'] ) || empty( $options['reset_url'] ) ) {
+				if ( empty( $options['reset_url'] ) ) {
 					echo esc_attr( tribe_get_events_link() );
 				} else {
 					echo esc_attr( $options['reset_url'] );
@@ -71,7 +71,7 @@ $terms = apply_filters( 'teccc_legend_terms', $teccc->terms );
 				?>
 				">
 					<?php
-					if ( ! isset( $options['reset_label'] ) || empty( $options['reset_label'] ) ) {
+					if ( empty( $options['reset_label'] ) ) {
 						esc_html_e( 'Reset', 'the-events-calendar-category-colors' );
 					} else {
 						echo esc_html( $options['reset_label'] );

--- a/src/views/legend.php
+++ b/src/views/legend.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/views/mobile.css.php
+++ b/src/views/mobile.css.php
@@ -4,7 +4,7 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -4,16 +4,18 @@
  *
  * @author   Andy Fragen
  * @license  MIT
- * @link     https://github.com/afragen/the-events-calendar-category-colors
+ * @link     https://github.com/the-events-calendar/the-events-calendar-category-colors
  * @package  the-events-calendar-category-colors
  */
 
 namespace Fragen\Category_Colors;
 
+_deprecated_file( __FILE__, 'TBD', 'the-events-calendar-category-colors' );
+
 $teccc->setup_terms( $options );
 
 ?>
-<table class="teccc form-table" xmlns="http://www.w3.org/1999/html">
+<table class="teccc form-table tec-settings-form__content-section" xmlns="http://www.w3.org/1999/html">
 
 	<tr>
 		<th style="width:10px;"><strong><?php esc_html_e( 'Hide', 'the-events-calendar-category-colors' ); ?></strong>
@@ -37,8 +39,8 @@ $teccc->setup_terms( $options );
 				</label>
 				<?php
 				if ( ! empty( $options['hide'][ $slug ] ) ) {
-					$options[ "{$slug}-border_none" ]     = isset( $options[ "{$slug}-border_none" ] ) ? $options[ "{$slug}-border_none" ] : '';
-					$options[ "{$slug}-background_none" ] = isset( $options[ "{$slug}-background_none" ] ) ? $options[ "{$slug}-background_none" ] : '';
+					$options[ "{$slug}-border_none" ]     = $options[ "{$slug}-border_none" ] ?? '';
+					$options[ "{$slug}-background_none" ] = $options[ "{$slug}-background_none" ] ?? '';
 				}
 				?>
 			</td>
@@ -56,7 +58,7 @@ $teccc->setup_terms( $options );
 						?>
 					<?php endif ?>
 				</div>
-				<div class="colorselector">
+				<div class="color-selector">
 					<label>
 						<input class="teccc-color-picker" type="text" name="teccc_options[<?php echo esc_attr( $slug ); ?>-border]" value="<?php echo esc_attr( $options[ "{$slug}-border" ] ); ?>" />
 					</label>
@@ -74,7 +76,7 @@ $teccc->setup_terms( $options );
 						?>
 					<?php endif ?>
 				</div>
-				<div class="colorselector">
+				<div class="color-selector">
 					<label>
 						<input class="teccc-color-picker" type="text" name="teccc_options[<?php echo esc_attr( $slug ); ?>-background]" value="<?php echo esc_attr( $options[ "{$slug}-background" ] ); ?>" />
 					</label>
@@ -88,21 +90,28 @@ $teccc->setup_terms( $options );
 						<?php endforeach ?>
 					</select> </label>
 			</td>
+			<?php
+				$style = '';
+				if ( ! empty( $options[ "{$slug}-background" ] ) ) :
+					$option = $options[ "{$slug}-background" ];
+					$style .= "background-color: {$option};";
+				endif;
 
+				if ( ! empty( $options[ "{$slug}-border" ] ) ) :
+					$option = $options[ "{$slug}-border" ];
+					$style .= "border-left: 5px solid {$option};";
+				endif;
+
+				if ( 'no_color' !== $options[ "{$slug}-text" ] ) :
+					$option = $options[ "{$slug}-text" ];
+					$style .= "color: {$option};";
+				endif;
+
+				$option = $options[ 'font_weight' ];
+				$style .= "border-right: 5px solid transparent; font-weight: {$option}; padding: 0.5em 1em;"
+			?>
 			<td>
-				<span style="
-				<?php if ( ! empty( $options[ "{$slug}-background" ] ) ) : ?>
-					background-color: <?php echo esc_attr( $options[ $slug . '-background' ] ); ?>;
-				<?php endif ?>
-				<?php if ( ! empty( $options[ "{$slug}-border" ] ) ) : ?>
-					border-left: 5px solid <?php echo esc_attr( $options[ "{$slug}-border" ] ); ?>;
-				<?php endif ?>
-					border-right: 5px solid transparent;
-				<?php if ( 'no_color' !== $options[ "{$slug}-text" ] ) : ?>
-					color:<?php echo esc_attr( $options[ "{$slug}-text" ] ); ?>;
-				<?php endif ?>
-					padding: 0.5em 1em;
-					font-weight: <?php echo esc_attr( $options['font_weight'] ); ?>;">
+				<span style="<?php echo esc_attr( $style ); ?>">
 					<?php echo esc_html( $name ); ?>
 				</span>
 			</td>
@@ -124,7 +133,7 @@ $teccc->setup_terms( $options );
 					?>
 				<?php endif ?>
 			</div>
-			<div class="colorselector">
+			<div class="color-selector">
 				<label>
 					<input class="teccc-color-picker" type="text" name="teccc_options[featured-event]" value="<?php echo esc_attr( $options['featured-event'] ); ?>" />
 				</label>

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -53,7 +53,7 @@ $teccc->setup_terms( $options );
 						<input name="teccc_options[<?php echo esc_attr( $slug ); ?>-border_none]" type="checkbox" value="1" <?php checked( '1', $options[ "{$slug}-border_none" ] ); ?> /> <?php esc_html_e( 'No Border', 'the-events-calendar-category-colors' ); ?>
 					</label><br>
 					<?php
-					if ( '1' === $options[ "{$slug}-border_none" ] ) :
+					if ( ! empty( $options[ "{$slug}-border_none" ] ) ) :
 						$options[ "{$slug}-border" ] = '';
 						?>
 					<?php endif ?>
@@ -71,7 +71,7 @@ $teccc->setup_terms( $options );
 						<input name="teccc_options[<?php echo esc_attr( $slug ); ?>-background_none]" type="checkbox" value="1" <?php checked( '1', $options[ "{$slug}-background_none" ] ); ?> /> <?php esc_html_e( 'No Background', 'the-events-calendar-category-colors' ); ?>
 					</label><br>
 					<?php
-					if ( '1' === $options[ "{$slug}-background_none" ] ) :
+					if ( ! empty( $options[ "{$slug}-background_none" ] ) ) :
 						$options[ "{$slug}-background" ] = '';
 						?>
 					<?php endif ?>
@@ -128,7 +128,7 @@ $teccc->setup_terms( $options );
 					<input name="teccc_options[featured-event_none]" type="checkbox" value="1" <?php checked( '1', $options['featured-event_none'] ); ?> /> <?php esc_html_e( 'Transparent', 'the-events-calendar-category-colors' ); ?>
 				</label><br>
 				<?php
-				if ( '1' === $options['featured-event_none'] ) :
+				if ( ! empty( $options['featured-event_none'] ) ) :
 					$options['featured-event'] = 'transparent';
 					?>
 				<?php endif ?>

--- a/src/views/optionsform.php
+++ b/src/views/optionsform.php
@@ -15,10 +15,6 @@ $teccc->setup_terms( $options );
 ?>
 <table class="teccc form-table" xmlns="http://www.w3.org/1999/html">
 
-	<style type="text/css">.form-table th {
-			font-size: 12px;
-		}</style>
-
 	<tr>
 		<th style="width:10px;"><strong><?php esc_html_e( 'Hide', 'the-events-calendar-category-colors' ); ?></strong>
 		</th>
@@ -199,16 +195,16 @@ $teccc->setup_terms( $options );
 		<?php esc_html_e( 'For this option you have to show the category legend at least on one view.', 'the-events-calendar-category-colors' ); ?>
 	</div>
 	<div class="teccc_options_col2 legend_related">
-		<input name="teccc_options[reset_show]" type="checkbox" value="1" <?php checked( '1', $options['reset_show'] ); ?> />
-		<label for="teccc_options[reset_show]"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="teccc_options_reset_show" name="teccc_options[reset_show]" type="checkbox" value="1" <?php checked( '1', $options['reset_show'] ); ?> />
+		<label for="teccc_options_reset_show"><?php esc_html_e( 'Show reset button', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div class="teccc_options_col2 legend_related">
-		<input name="teccc_options[reset_label]" type="text" placeholder="<?php esc_html_e( 'Reset', 'the-events-calendar-category-colors' ); ?>" value="<?php echo esc_attr( $options['reset_label'] ); ?>" />
-		<label for="teccc_options[reset_label]"><?php esc_html_e( 'Reset button label', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="teccc_options_reset_label" name="teccc_options[reset_label]" type="text" placeholder="<?php esc_html_e( 'Reset', 'the-events-calendar-category-colors' ); ?>" value="<?php echo esc_attr( $options['reset_label'] ); ?>" />
+		<label for="teccc_options_reset_label"><?php esc_html_e( 'Reset button label', 'the-events-calendar-category-colors' ); ?></label>
 	</div>
 	<div class="teccc_options_col2 legend_related">
-		<input name="teccc_options[reset_url]" type="text" placeholder="<?php echo esc_attr( tribe_get_events_link() ); ?>" value="<?php echo esc_attr( $options['reset_url'] ); ?>" />
-		<label for="teccc_options[reset_url]"><?php esc_html_e( 'Reset button URL', 'the-events-calendar-category-colors' ); ?></label>
+		<input id="teccc_options_reset_url" name="teccc_options[reset_url]" type="text" placeholder="<?php echo esc_attr( tribe_get_events_link() ); ?>" value="<?php echo esc_attr( $options['reset_url'] ); ?>" />
+		<label for="teccc_options_reset_url"><?php esc_html_e( 'Reset button URL', 'the-events-calendar-category-colors' ); ?></label>
 		<p><?php esc_html_e( 'By default the reset button will point to the default calendar URL.', 'the-events-calendar-category-colors' ); ?></p>
 	</div>
 	</div>

--- a/the-events-calendar-category-colors.php
+++ b/the-events-calendar-category-colors.php
@@ -12,7 +12,7 @@
  * Plugin Name:       The Events Calendar: Category Colors
  * Plugin URI:        https://github.com/the-events-calendar/the-events-calendar-category-colors
  * Description:       This plugin adds event category background coloring to <a href="http://wordpress.org/plugins/the-events-calendar/">The Events Calendar</a> plugin.
- * Version:           7.3.2
+ * Version:           7.4.0
  * Text Domain:       the-events-calendar-category-colors
  * Domain Path:       /languages
  * Author:            Andy Fragen, Barry Hughes
@@ -20,8 +20,8 @@
  * License:           GNU General Public License v2
  * License URI:       http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * GitHub Plugin URI: https://github.com/the-events-calendar/the-events-calendar-category-colors
- * Requires PHP:      7.1
- * Requires at least: 5.2
+ * Requires at least: 6.3
+ * Requires PHP:      7.4
  * Requires Plugins:  the-events-calendar
  */
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -18,7 +18,7 @@
  * For more information, see the following discussion:
  * https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/pull/123#issuecomment-28541913
  *
- * @link       https://github.com/afragen/the-events-calendar-category-colors
+ * @link       https://github.com/the-events-calendar/the-events-calendar-category-colors
  *
  * @package    Fragen\Category_Colors\Main
  */


### PR DESCRIPTION
Fix settings so they save correctly, includes updating the settings to:

- fit into our new settings styles,
- save properly,
- utilize the TCMN settings object

I also:
- fixed an issue where the legend styles would not load on the FE, 
- updated the plugin requirements to match TEC, 
- deprecated some functions properly, 
- used our views manager to get the list of active views (rather than hardcoding and using `class_exists` for ECP)
- removed out of date donate links and repo links


[TECTRIA-417]


[TECTRIA-417]: https://stellarwp.atlassian.net/browse/TECTRIA-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ