### PR TITLE
Fix `_load_textdomain_just_in_time` error from Main::get_plugin_version()

### DIFF
--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -453,12 +453,7 @@ class Main {
 	 * @return string
 	 */
 	public static function get_plugin_version( $file ) {
-		if ( ! function_exists( 'get_plugin_data' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-		$plugin_data = \get_plugin_data( $file );
-
-		return $plugin_data['Version'];
+		return get_file_data( $file, [ 'Version' => 'Version' ] )['Version'];
 	}
 
 	/**


### PR DESCRIPTION
Replace get_plugin_data() with get_file_data() to avoid translation issue that can occur with get_plugin_data(). Since we only need the version the header doesn't need to be translated.

#169 