### PR TITLE
Fix _load_textdomain_just_in_time error from Main::get_plugin_version()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 7.4.1 / 2025-01-15
+
+* Fix - Resolve translation issue that can occur with get_plugin_data(). [TEC-5350]
+
 #### 7.3.1 / 2024-07-09
 
 * Fix - Resolve problem for PHP 8+, avoid passing pass `null` to string specific functions. (props @afragen) [TECENG-58]

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,10 @@ Make sure you are reporting in a safe and responsible way. We take security very
 
 ## Changelog
 
+#### 7.4.1 / 2025-01-15
+
+* Fix - Resolve translation issue that can occur with get_plugin_data(). [TEC-5350]
+
 #### 7.4.0 / 2024-11-14
 
 * Fix - Make sure we have fully compatible settings save with the new TEC settings page.

--- a/src/Category_Colors/Main.php
+++ b/src/Category_Colors/Main.php
@@ -473,12 +473,7 @@ class Main {
 	 * @return string
 	 */
 	public static function get_plugin_version( $file ) {
-		if ( ! function_exists( 'get_plugin_data' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-		$plugin_data = \get_plugin_data( $file );
-
-		return $plugin_data['Version'];
+		return get_file_data( $file, [ 'Version' => 'Version' ] )['Version'];
 	}
 
 	/**


### PR DESCRIPTION
Replace get_plugin_data() with get_file_data() to avoid translation issue that can occur with get_plugin_data(). Since we only need the version the header doesn't need to be translated.

[TEC-5350]

see: #170, #169

[TEC-5350]: https://stellarwp.atlassian.net/browse/TEC-5350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ